### PR TITLE
Fix license information

### DIFF
--- a/sh.fhs.KatawaShoujoReEngineered.appdata.xml
+++ b/sh.fhs.KatawaShoujoReEngineered.appdata.xml
@@ -38,7 +38,7 @@
             <url>https://codeberg.org/fhs/katawa-shoujo-re-engineered/releases/tag/v1.3.0</url>
         </release>
     </releases>
-    <project_license>CC-BY-NC-ND-3.0</project_license>
+    <project_license>MPL-2.0</project_license>
     <developer_name>Fleeting Heartbeat Studios</developer_name>
     <screenshots>
         <screenshot>


### PR DESCRIPTION
As described in the appdata manifest documentation, we should use main license for project for not confusing users.

As the code of KS:RE is licensed under MPL-2.0, I put it here.