### PR TITLE
Release v1.4.8

### DIFF
--- a/sh.fhs.KatawaShoujoReEngineered.appdata.xml
+++ b/sh.fhs.KatawaShoujoReEngineered.appdata.xml
@@ -31,6 +31,21 @@
     <url type="faq">https://www.fhs.sh/about</url>
     <launchable type="desktop-id">sh.fhs.KatawaShoujoReEngineered.desktop</launchable>
     <releases>
+        <release version="1.4.8" date="2024-10-02">
+            <description>
+                <p>This release is dedicated to XPND.Dev, a founding member of our team, who is sadly no longer among us.</p>
+                <ul>
+                    <li>Added Simplified Chinese translation (thanks to @CloneWith!).</li>
+                    <li>Fixed "name only" characters having no quotes in dialogues.</li>
+                    <li>Hanako nude sprite won't show with adult content disabled.</li>
+                    <li>Upgraded Ren'Py to 8.3.2</li>
+                    <li>Improved Spanish and French translations.</li>
+                    <li>Fixed a typo in the Hanako route.</li>
+                    <li>Fixed broken link between "Slow Recovery" and "Exercise" scenes (thanks to @whizfox!)</li>
+                </ul>
+            </description>
+            <url>https://codeberg.org/fhs/katawa-shoujo-re-engineered/releases/tag/v1.4.8</url>
+        </release>
         <release version="1.4.7" date="2024-04-21">
             <description>
                 <ul>

--- a/sh.fhs.KatawaShoujoReEngineered.yaml
+++ b/sh.fhs.KatawaShoujoReEngineered.yaml
@@ -11,7 +11,6 @@ add-extensions:
     autodelete: false
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --socket=fallback-x11
   - --socket=wayland
   - --device=all
@@ -40,7 +39,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/renpy/pygame_sdl2.git
-        tag: renpy-8.1.0.23050902
+        tag: renpy-8.3.1.24090601
 
   - name: mbrola
     buildsystem: simple
@@ -88,8 +87,8 @@ modules:
       - install -Dm755 renpy.sh "${FLATPAK_DEST}/bin/renpy"
     sources:
       - type: archive
-        url: https://www.renpy.org/dl/8.1.3/renpy-8.1.3-source.tar.bz2
-        sha256: e207b080acc6721eb51bdbb5f1021d18bb0b8bfb79116cf683dd9fdb5bf9cebc
+        url: https://www.renpy.org/dl/8.3.2/renpy-8.3.2-source.tar.bz2
+        sha256: 4a9677b988d7bfcf9f028c1044accff6b00effe8ec2105814dab04ff473db80b
       - type: script
         commands:
           - python /app/share/renpy/renpy.py "$@"
@@ -109,7 +108,7 @@ modules:
     sources:
       - type: git
         url: https://codeberg.org/fhs/katawa-shoujo-re-engineered.git
-        tag: v1.4.7
+        tag: v1.4.8
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
This is Katawa Shoujo: Re-Engineered release v1.4.8.

This release is dedicated to XPND.Dev, a founding member of our team, who is sadly no longer among us.